### PR TITLE
Persist isCompleted value to db

### DIFF
--- a/src/factories/todo-factory.js
+++ b/src/factories/todo-factory.js
@@ -27,7 +27,8 @@ const todoFactory = angular.module('app.todoFactory', [])
     }
 
     function updateTask($scope, todo) {
-        $http.put(`/todos/${todo._id}`, { task: todo.updatedTask }).success(response => {
+        $http.put(`/todos/${todo._id}`, { task: todo.updatedTask,
+                                          isCompleted: todo.isCompleted }).success(response => {
             getTasks($scope);
             todo.isEditing = false;
         });

--- a/src/server/todos/routes.js
+++ b/src/server/todos/routes.js
@@ -23,7 +23,9 @@ router.post('/', function(req, res) {
 router.put('/:id', function(req, res) {
     var id = req.params.id;
     Todo.update({ _id: mongoose.Types.ObjectId(id) }, {
-        $set: { task: req.body.task }
+        $set: { task: req.body.task,
+                isCompleted: req.body.isCompleted
+              }
     }, function(err) {
         if (err) { console.log(err); }
 

--- a/src/todos/todos.html
+++ b/src/todos/todos.html
@@ -17,7 +17,7 @@
             <td>
                 <input type="checkbox"
                     ng-checked="todo.isCompleted"
-                    ng-click="onCompletedClick(todo)" />
+                    ng-click="onCompletedClick(todo); updateTask(todo)" />
             </td>
             <td>
                 <span ng-if="!todo.isEditing"

--- a/src/todos/todos.js
+++ b/src/todos/todos.js
@@ -22,6 +22,7 @@ export default function($scope, todoFactory) {
 
     $scope.onCompletedClick = todo => {
         todo.isCompleted = !todo.isCompleted;
+        todo.updatedTask  = todo.task;
     };
 
     $scope.onEditClick = todo => {


### PR DESCRIPTION
Not sure if this is the cleanest way to do it, but I noticed the `isCompleted` value doesn't persist to db when the checkbox is clicked.

I didn't want to create any new methods here, so I just added the `updateTask` method to the `ng-click` for the `isCompleted` checkbox.

If there's a better way to approach this and you've got time to explain it, I'd love to know, thanks!
